### PR TITLE
doc: update build process to get RC_VERSION

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -61,6 +61,7 @@ author = u'Project ARCN developers'
 try:
     version_major = None
     version_minor = None
+    version_rc = None
     for line in open(os.path.normpath("../acrn-hypervisor/Makefile")) :
         if line.count("=") :
            key, val = [x.strip() for x in line.split('=', 2)]
@@ -68,13 +69,15 @@ try:
               version_major = val
            if key == 'MINOR_VERSION':
               version_minor = val
-           if version_major and version_minor :
+           if key == 'RC_VERSION':
+              version_rc = val
+           if version_major and version_minor and version_rc :
               break
 except:
     pass
 finally:
-    if version_major and version_minor :
-        version = release = "v " + version_major + '.' + version_minor
+    if version_major and version_minor and version_rc :
+        version = release = "v " + version_major + '.' + version_minor + '.' + version_rc
     else:
         sys.stderr.write('Warning: Could not extract hypervisor version from Makefile\n')
         version = release = "unknown"

--- a/scripts/pullsource.sh
+++ b/scripts/pullsource.sh
@@ -11,5 +11,15 @@ if [ ! -d "../acrn-devicemodel" ]; then
   exit -1
 fi
 
-cd ../acrn-hypervisor;git pull
-cd ../acrn-devicemodel;git pull
+cd ../acrn-hypervisor
+git checkout master;
+git fetch upstream
+git merge upstream/master
+git push origin master
+
+
+cd ../acrn-devicemodel
+git checkout master;
+git fetch upstream
+git merge upstream/master
+git push origin master


### PR DESCRIPTION
Doc version tracking with acrn-hypervisor version now to be
MAJOR_VERSION . MINOR_VERSION . RC_VERSION

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>