### PR TITLE
doc: add CODEOWNERS for assigning reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS for autoreview assigning in github
+
+# Get all docs reviewed
+*.rst                                    @dbkinder
+
+*                                        @dbkinder


### PR DESCRIPTION
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>