### PR TITLE
doc: update display of RC version

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -77,7 +77,9 @@ except:
     pass
 finally:
     if version_major and version_minor and version_rc :
-        version = release = "v " + version_major + '.' + version_minor + '.' + version_rc
+        version = release = "v " + version_major + '.' + version_minor
+        if int(version_rc) > 0 :
+           version = release = version + '-rc' + version_rc
     else:
         sys.stderr.write('Warning: Could not extract hypervisor version from Makefile\n')
         version = release = "unknown"


### PR DESCRIPTION
Change display of RC_VERSION on documents to be
  vMAJOR_VERSION.MINOR_VERSION-rcRC_VERSION
if RC_VERSION is non-zero, otherwise only
  vMAJOR_VERSION.MINOR_VERSION

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>