### PR TITLE
doc: Update publish process in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ publish:
 	rm -fr $(PUBLISHDIR)/*
 	cp -r $(BUILDDIR)/html/* $(PUBLISHDIR)
 	cp scripts/publish-README.md $(PUBLISHDIR)/README.md
+	cd $(PUBLISHDIR); git add -A; git commit -s -m "publish"; git push origin master;
 
 
 # Catch-all target: route all unknown targets to Sphinx using the new


### PR DESCRIPTION
Simplify the publishing process to projectacrn.github.io by making
commits directly to the projectacrn/projectacrn.github.io repo (rather
than to a personal repo, doing a PR, and processing the PR).  This
eliminates manual processing in an otherwise automated publishing
process:  PR reviews aren't needed for this step.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>