### PR TITLE
doc: fix doxy for hiding internal symbols

### DIFF
--- a/acrn.doxyfile
+++ b/acrn.doxyfile
@@ -866,7 +866,7 @@ EXCLUDE_PATTERNS       =
 # Exclude internal names (starting with an _) and doxygen-added __unnamed__
 # names given to unnamed nested unions
 
-EXCLUDE_SYMBOLS        = _*, *.__unnamed__
+EXCLUDE_SYMBOLS        = _* *.__unnamed__
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION
Doxygen syntax for EXCLUDE_SYMBOLS is with spaces for separator,
not commas.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>