### PR TITLE
doc: update project documentation LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,3 @@
+ARCN Project Documentation is under a Creative Commons Attribution 4.0
+International License (CC BY 4.0).  For details, see
+https://creativecommons.org/licenses/by/4.0/.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ doxy: pullsource
 	$(Q)(cat acrn.doxyfile) | doxygen -  2>&1
 
 html: doxy
-	$(Q)$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" "$(SPHINXOPTS)" $(O) > doc.log 2>&1
+	$(Q)$(SPHINXBUILD) -b html -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(O) > doc.log 2>&1
 	$(Q)./scripts/filter-doc-log.sh doc.log
 
 

--- a/_templates/footer.html
+++ b/_templates/footer.html
@@ -1,0 +1,8 @@
+{% extends "!footer.html" %}
+{% block extrafooter %}
+    <p class="extrafooter">Documentation licensed under <a rel="license"
+    href="http://creativecommons.org/licenses/by/4.0/">(CC BY 4.0) <img
+    alt="Creative Commons License" style="border-width:0"
+    src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a></p>
+    {{ super() }}
+{% endblock %}

--- a/static/acrn-custom.css
+++ b/static/acrn-custom.css
@@ -35,6 +35,11 @@ span.caption-number::after {
    content: ": ";
 }
 
+p.extrafooter {
+   text-align: right;
+   margin-top: -36px;
+}
+
 table.align-center {
    display: table !important;
 }


### PR DESCRIPTION
Per Project ACRN governance, documentation is under a Creative Commons
Attribution 4.0 International License (CC BY 4.0).  This patch updates
this information, and adds a tagline to documentation mentioning this
license.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>