### PR TITLE
Makefile (uefi): fix path to gnu-efi linker for Fedora/CentOS

### DIFF
--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -338,6 +338,7 @@ each with their own way to install development tools:
   .. code-block:: console
 
      $ sudo dnf install gcc \
+          gnu-efi \
           libuuid-devel \
           openssl-devel \
           libpciaccess-devel
@@ -347,6 +348,7 @@ each with their own way to install development tools:
   .. code-block:: console
 
      $ sudo yum install gcc \
+             gnu-efi-devel \
              libuuid-devel \
              openssl-devel \
              libpciaccess-devel


### PR DESCRIPTION
Add the 'gnu-efi' dependency required to build the ACRN hypervisor
with "PLATFORM=uefi" on Fedora/CentOS. Also add a note that
bsp/uefi/efi/Makefile needs to be modified to account for the
folder path (which is different than on Debian/Ubuntu for example)

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>