### PR TITLE
getting_started: update dependency for Fedora 27

### DIFF
--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -338,7 +338,7 @@ each with their own way to install development tools:
   .. code-block:: console
 
      $ sudo dnf install gcc \
-          gnu-efi \
+          gnu-efi-devel \
           libuuid-devel \
           openssl-devel \
           libpciaccess-devel


### PR DESCRIPTION
Update the build dependency for Fedora. 'gnu-efi' was listed as
a dependency but it's actually 'gnu-efi-devel' that we need else
the header file ('efi.h') is not installed.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>