### PR TITLE
doc: fix doc build processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ pullsource:
 # Generate the doxygen xml (for Sphinx) and copy the doxygen html to the
 # api folder for publishing along with the Sphinx-generated API docs.
 
-doxy: pullsource
+#doxy: pullsource
+doxy:
 	$(Q)(cat acrn.doxyfile) | doxygen - > doc.log 2>&1
 
 html: doxy

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository hold the source and configuration files used to generate the
 Project ACRN documentation web site published to
-https://projectacrn.github.io/acrn-documentation
+https://projectacrn.github.io


### PR DESCRIPTION
Some assumptioins about the doc build process were removed to make it
easier for contributors to build local version of the docs.  Assumption
now is that acrn-hypervisor and acrn-devicemodel content is up to date
rather than pulling from upstream on every build.

make pullsource    will do an upstream pull manually
make html          generates local docs

Also fixed broken link in the README.md file (moved the tech doc root)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>