### PR TITLE
doc: GSG formating fix, RTD theme tweak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,14 @@ PUBLISHDIR    = ../projectacrn.github.io/$(RELEASE)
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo ""
+	@echo "make pullsource"
+	@echo "   fetch and merge upstream source for the project ACRN code repos"
+	@echo ""
+	@echo "make publish"
+	@echo "   publish generated html to projectacrn.github.io site:"
+	@echo "   specify RELEASE=name to publish as a tagged release version"
+	@echo "   and placed in a version subfolder"
 
 .PHONY: help Makefile
 

--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -113,11 +113,11 @@ partition. Follow these steps:
       kernel-org.clearlinux.pk414-standard.4.14.34-28
       loaderx64.efi
 
-      .. note::
-         The Clear Linux project releases updates often, sometimes
-         twice a day, so make note of the specific kernel versions (``*-sos``
-         and ``*-standard``) listed on your system,
-         as you will need them later.
+   .. note::
+      The Clear Linux project releases updates often, sometimes
+      twice a day, so make note of the specific kernel versions (``*-sos``
+      and ``*-standard``) listed on your system,
+      as you will need them later.
 
 #. Put the ``acrn.efi`` hypervisor application (included in the Clear
    Linux release) on the EFI partition with:
@@ -140,13 +140,14 @@ partition. Follow these steps:
       # cd /mnt/EFI/org.clearlinux/
       # cp bootloaderx64.efi bootloaderx64_origin.efi
 
-      .. note::
-         Be aware that a Clearlinux update that includes a kernel upgrade will
-         reset this. A Clearlinux update could happen automatically (if you have
-         not disabled it as described above), if you later install a new
-         bundle to your system or simply if you decide to trigger an update
-         manually. Whenever that happens, double-check the platform boot order
-         using ``efibootmgr -v`` and modify it if needed.
+   .. note::
+      Be aware that a Clearlinux update that includes a kernel upgrade will
+      reset the boot option changes you just made.. A Clearlinux update could
+      happen automatically (if you have
+      not disabled it as described above), if you later install a new
+      bundle to your system, or simply if you decide to trigger an update
+      manually. Whenever that happens, double-check the platform boot order
+      using ``efibootmgr -v`` and modify it if needed.
 
 #. Create a boot entry for the ACRN Service OS by copying a provided ``acrn.conf``
    and editing it to account for the kernel versions noted in a previous step.
@@ -196,6 +197,7 @@ partition. Follow these steps:
 
    .. figure:: images/gsg-bootmenu.png
       :align: center
+      :width: 650px
       :name: gsg-bootmenu
 
       ACRN Service OS Boot menu

--- a/scripts/publish-index.html
+++ b/scripts/publish-index.html
@@ -5,6 +5,6 @@
 <meta name="keywords" content="automatic redirection">
 </head>
 <body>
-Please visit the <a href="/latest/">latest ARCN documentation</a>
+Please visit the <a href="/latest/">latest ACRN documentation</a>
 </body>
 </html>

--- a/static/acrn-custom.css
+++ b/static/acrn-custom.css
@@ -14,12 +14,12 @@
 }
 */
 
-/* tweak doc version selection */
+/* tweak doc version selection
 .rst-versions {
    position: static;
    border-top: none;
    padding: 0px;
-}
+} */
 
 .rst-versions .rst-current-version {
    padding: 5px;
@@ -33,6 +33,15 @@
 
 div.rst-other-versions dl {
    margin-bottom: 0;
+}
+
+/* code block highlight color in rtd changed to lime green, no no no */
+
+.rst-content tt.literal, .rst-content code.literal, .highlight {
+   background: #f0f0f0;
+}
+.rst-content tt.literal, .rst-content code.literal {
+    color: #000000;
 }
 
 /* Make the version number more visible */


### PR DESCRIPTION
Fix some formatting problems with a recent GSG update.  Tweak the
custom CSS to adjust code block (and code literal) colors.  Update
Makefile to document doc build options for pulling source from the other
repos and for publishing targets.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>